### PR TITLE
feat: Version bump to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coc-pairs",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Auto pair extension for coc.nvim",
   "main": "lib/index.js",
   "publisher": "chemzqm",


### PR DESCRIPTION
I forgot to bump the package version in my [previous PR](https://github.com/neoclide/coc-pairs/pull/7).  I believe this is why running `:CocUpdateSync` does not pull in the latest changes.

@chemzqm If you would rather handle this yourself at a later time, feel free to disregard this PR.