### PR TITLE
Fix doubled single quotes when they should be closed.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
     let pre = line.slice(0, pos.character)
     let rest = line.slice(pos.character)
     if (rest && isWord(rest[0])) return character
-    if (samePair && pre && isWord(pre[pre.length - 1])) return character
     if (character == '<' && (pre[pre.length - 1] == ' ' || pre[pre.length - 1] == '<')) {
       return character
     }
@@ -47,6 +46,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
       await nvim.eval(`feedkeys("\\<Right>", 'int')`)
       return ''
     }
+    if (samePair && pre && isWord(pre[pre.length - 1])) return character
     // Only pair single quotes if previous character is not word.
     if (character === "'" && pre.match(/.*\w$/)) {
       return character


### PR DESCRIPTION
Typing this on a new line: `require('some-dep')`
Would lead to this: `require('some-dep'')`

This was caused by the fact that the [`if` clause for checking to see if the next character was a non-whitespace character](https://github.com/atomdmac/coc-pairs/blob/6c739dbbb63c62f87a10598c63da937110e586ab/src/index.ts#L49) ("`isWord`") was triggered prior to the [`if` clause for skipping the cursor ahead when the closing single-quote was entered](https://github.com/atomdmac/coc-pairs/blob/6c739dbbb63c62f87a10598c63da937110e586ab/src/index.ts#L44).