### PR TITLE
fix: incorrect cursor position for multi-characters pairs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     if (character == '"') {
       nvim.command(`call feedkeys('""'."\\<Left>", 'int')`, true)
     } else {
-      nvim.command(`call feedkeys("${character}${pair}\\<Left>", 'int')`, true)
+      nvim.command(`call feedkeys("${character}${pair}${"\\<Left>".repeat(pair.length)}", 'int')`, true)
     }
     return ''
   }


### PR DESCRIPTION
如果是这样的设置
```
autocmd FileType html let b:coc_paires = [['<!--', '-->']]
```
括号补全后光标往回跳的数目就不够
```
<!----|>
```