### PR TITLE
Add a way to handle lifetime params in Rust

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
     if (character === "'" && pre.match(/.*\w$/)) {
       return character
     }
-    // Rust: don't pair single quotes that are part of lifetime annotations Foo::<'a>
-    if (filetype === 'rust' && character === "'" && pre.endsWith('<')) {
+    // Rust: don't pair single quotes that are part of lifetime annotations such as `Foo::<'a, 'b>` or `bar: &'a str`
+    if (
+      filetype === 'rust' && character === "'" &&
+      (pre.endsWith('<') || rest.startsWith('>') || pre.endsWith('&'))
+    ) {
       return character
     }
     if ((filetype === 'vim' || filetype === 'help') && character === '"' && pos.character === 0) {


### PR DESCRIPTION
By PR #38, Rust lifetime params, which are apostrophes, have been handled correctly only when they are placed after `<`.
But it doesn't work well in the following two cases:

1. multiple lifetime params like `Foo::<'a, 'b>`
2. explicit lifetime annotation like `bar: &'a str`

So this PR deals with the above two cases.